### PR TITLE
Enable Intake GUI for thumbnails and geotiffs

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -26,6 +26,7 @@ dependencies:
   - isort
   - jupyterlab
   - make
+  - matplotlib
   - nbsphinx
   - netcdf4
   - nodejs >=10.0.0
@@ -44,6 +45,7 @@ dependencies:
   - rasterio
   - recommonmark
   - requests
+  - sat-search>=0.3
   - sat-stac
   - scikit-image
   - sphinx_rtd_theme
@@ -51,5 +53,4 @@ dependencies:
   - xarray
   - pip:
       - git+https://github.com/intake/intake-stac@master
-      - sat-search>=0.3
       - sphinx_copybutton

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -51,5 +51,5 @@ dependencies:
   - xarray
   - pip:
       - git+https://github.com/intake/intake-stac@master
-      - sat-search==0.3.0rc1
+      - sat-search>=0.3
       - sphinx_copybutton

--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,19 +1,55 @@
-name: intake-stac
+# Intake GUI also requires jupyterlab extensions installed
+# jupyter labextension install @pyviz/jupyterlab_pyviz
+name: intake-stac-gui
 channels:
   - conda-forge
-  - informaticslab
 dependencies:
-  - python=3
+  - aiohttp
+  - autopep8
+  - black
   - boto3
+  - codecov
+  - coverage
+  - dask
+  - datashader
+  - distributed
+  - flake8
   - geopandas
+  - geoviews
+  - hvplot
   - intake
-  - intake_geopandas
+  - intake-geopandas
+  - intake-parquet
   - intake-xarray
-  - rasterio
-  - sat-stac
-  - sat-search
+  - ipykernel
+  - ipywidgets
+  - isort
+  - jupyterlab
+  - make
+  - nbsphinx
   - netcdf4
-  - rasterio
-  - scikit-image
-  - matplotlib
+  - nodejs >=10.0.0
+  - numpy
+  - numpydoc
+  - pandoc
+  - panel
   - pip
+  - pre_commit
+  - pytest
+  - pytest-cov
+  - pytest-icdiff
+  - python =3.7
+  - pytoml
+  - pyyaml
+  - rasterio
+  - recommonmark
+  - requests
+  - sat-stac
+  - scikit-image
+  - sphinx_rtd_theme
+  - sphinx >=1.6
+  - xarray
+  - pip:
+      - git+https://github.com/intake/intake-stac@master
+      - sat-search==0.3.0rc1
+      - sphinx_copybutton

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,5 +1,8 @@
 #!/bin/bash
-set -euo pipefail
 
-# Install development version of intake-stack
-pip install .
+jupyter labextension install --clean \
+                             @jupyter-widgets/jupyterlab-manager \
+                             @jupyterlab/geojson-extension \
+                             @pyviz/jupyterlab_pyviz
+
+#EOF

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -36,11 +36,11 @@ dependencies:
   - rasterio
   - recommonmark
   - requests
+  - sat-search>=0.3
   - sat-stac
   - scikit-image
   - sphinx_rtd_theme
   - sphinx>=1.6
   - xarray
   - pip:
-      - sat-search>=0.3
       - sphinx_copybutton

--- a/ci/environment-dev-3.6.yml
+++ b/ci/environment-dev-3.6.yml
@@ -42,5 +42,5 @@ dependencies:
   - sphinx>=1.6
   - xarray
   - pip:
-      - sat-search==0.3.0rc1
+      - sat-search>=0.3
       - sphinx_copybutton

--- a/ci/environment-dev-3.7.yml
+++ b/ci/environment-dev-3.7.yml
@@ -36,11 +36,11 @@ dependencies:
   - rasterio
   - recommonmark
   - requests
+  - sat-search>=0.3
   - sat-stac
   - scikit-image
   - sphinx_rtd_theme
   - sphinx>=1.6
   - xarray
   - pip:
-      - sat-search>=0.3
       - sphinx_copybutton

--- a/ci/environment-gui-3.7.yml
+++ b/ci/environment-gui-3.7.yml
@@ -1,4 +1,9 @@
-name: intake-stac-dev
+# Intake GUI also requires jupyterlab extensions installed
+# conda env create -f ci/environment-gui-3.7.yml
+# conda activate intake-stac-gui
+# pip install -e .
+# jupyter labextension install @pyviz/jupyterlab_pyviz
+name: intake-stac-gui
 channels:
   - conda-forge
 dependencies:
@@ -9,9 +14,12 @@ dependencies:
   - codecov
   - coverage
   - dask
+  - datashader
   - distributed
   - flake8
   - geopandas
+  - geoviews
+  - hvplot
   - intake
   - intake-geopandas
   - intake-parquet
@@ -19,18 +27,21 @@ dependencies:
   - ipykernel
   - ipywidgets
   - isort
+  - jupyterlab
   - make
   - nbsphinx
   - netcdf4
+  - nodejs >=10.0.0
   - numpy
   - numpydoc
   - pandoc
+  - panel
   - pip
   - pre_commit
   - pytest
   - pytest-cov
   - pytest-icdiff
-  - python=3.7
+  - python =3.7
   - pytoml
   - pyyaml
   - rasterio
@@ -39,7 +50,7 @@ dependencies:
   - sat-stac
   - scikit-image
   - sphinx_rtd_theme
-  - sphinx>=1.6
+  - sphinx >=1.6
   - xarray
   - pip:
       - sat-search>=0.3

--- a/ci/environment-gui-3.7.yml
+++ b/ci/environment-gui-3.7.yml
@@ -29,6 +29,7 @@ dependencies:
   - isort
   - jupyterlab
   - make
+  - matplotlib
   - nbsphinx
   - netcdf4
   - nodejs >=10.0.0
@@ -47,11 +48,11 @@ dependencies:
   - rasterio
   - recommonmark
   - requests
+  - sat-search>=0.3
   - sat-stac
   - scikit-image
   - sphinx_rtd_theme
   - sphinx >=1.6
   - xarray
   - pip:
-      - sat-search>=0.3
       - sphinx_copybutton

--- a/examples/aws-earth-search.ipynb
+++ b/examples/aws-earth-search.ipynb
@@ -18,8 +18,7 @@
    "source": [
     "%matplotlib inline\n",
     "import intake\n",
-    "import satsearch\n",
-    "import os"
+    "import satsearch"
    ]
   },
   {
@@ -31,10 +30,11 @@
     "bbox = [35.48, -3.24, 35.58, -3.14] # (min lon, min lat, max lon, max lat)\n",
     "dates = '2020-07-01/2020-08-15'\n",
     "\n",
-    "os.environ['STAC_API_URL'] = 'https://earth-search.aws.element84.com/v0' # \"stac_version\":\"1.0.0-beta.2\"\n",
-    "results = satsearch.Search.search(collections=['sentinel-s2-l2a-cogs'], # note collection='sentinel-s2-l2a-cogs' doesn't work\n",
+    "URL='https://earth-search.aws.element84.com/v0'\n",
+    "results = satsearch.Search.search(url=URL,\n",
+    "                                  collections=['sentinel-s2-l2a-cogs'], # note collection='sentinel-s2-l2a-cogs' doesn't work\n",
     "                                  datetime=dates,\n",
-    "                                  bbox=bbox,                                  \n",
+    "                                  bbox=bbox,    \n",
     "                                  sort=['<datetime'])"
    ]
   },

--- a/examples/aws-earth-search.ipynb
+++ b/examples/aws-earth-search.ipynb
@@ -74,15 +74,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "type(catalog)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "list(catalog)"
    ]
   },
@@ -188,14 +179,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "# Interactive plot with hvplot and datashader\n",
-    "#import hvplot.xarray\n",
-    "#NDVI.hvplot.image(x='x', y='y',\n",
-    "#                  cmap='BrBG', clim=(-1,1),\n",
-    "#                  rasterize=True, dynamic=True,\n",
-    "#                  width=700, height=500)"
-   ]
+   "source": []
   }
  ],
  "metadata": {

--- a/examples/intake-cmr-stac.ipynb
+++ b/examples/intake-cmr-stac.ipynb
@@ -1,0 +1,253 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Intake-STAC + NASA CMR\n",
+    "\n",
+    "NASA's Common Metadata Repository (CMR) now has a STAC endpoint https://github.com/nasa/cmr-stac. In theory we can use Intake-STAC to browse NASA's entire data catalog! \n",
+    "\n",
+    "**Warning: This example notebook is very experimental and mostly for testing purposes.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import intake"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# STAC catalogs sometimes don't have 'mimetype per asset'\n",
+    "# This blocks silences warnings related to this case\n",
+    "# https://github.com/intake/intake-stac/issues/59\n",
+    "import warnings\n",
+    "warnings.simplefilter('ignore')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# for development\n",
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import satsearch\n",
+    "satsearch.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# requires sat-search>0.3.0\n",
+    "!sat-search search --url=https://cmr.earthdata.nasa.gov/cmr-stac/ASF"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cat = intake.open_stac_catalog('https://cmr.earthdata.nasa.gov/cmr-stac/ASF/collections')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "[x['short_name'] for x in cat.metadata['collections']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "band_info = pd.DataFrame(cat.metadata['collections'])\n",
+    "band_info"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Easily get all endpoints and collections?\n",
+    "#import requests\n",
+    "URL = 'https://cmr.earthdata.nasa.gov/cmr-stac/ASF'\n",
+    "results = satsearch.Search.search(url=URL,\n",
+    "                                  collections=['C1595422627-ASF']\n",
+    "                                  )\n",
+    "items = results.items()\n",
+    "print('%s items' % len(items))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catalog = intake.open_stac_item_collection(items)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NOTE: import statement required for dynamic=True\n",
+    "import hvplot.xarray\n",
+    "intake.gui.add(catalog)\n",
+    "intake.gui"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Item ids not so informative!\n",
+    "#list(catalog)\n",
+    "item = catalog['G1636018550-ASF']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "list(item)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "item['browse'].metadata"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "item['data']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Need to figure out authentication\n",
+    "# https://github.com/intake/intake-stac/issues/60\n",
+    "da = item['data'].to_dask()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NOTE: this requires NASA URS Earthdata credentials in a .netrc file\n",
+    "#!wget https://grfn.asf.alaska.edu/door/download/S1-GUNW-A-R-087-tops-20141023_20141011-153856-27545N_25464N-PP-1a1a-v2_0_2.nc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!ls -ltrh S1-GUNW-A-R-087-tops-20141023_20141011-153856-27545N_25464N-PP-1a1a-v2_0_2.nc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!gdalinfo S1-GUNW-A-R-087-tops-20141023_20141011-153856-27545N_25464N-PP-1a1a-v2_0_2.nc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "localFile = 'S1-GUNW-A-R-087-tops-20141023_20141011-153856-27545N_25464N-PP-1a1a-v2_0_2.nc'\n",
+    "da = xr.open_dataset(localFile,\n",
+    "                     group='/science/grids/data')\n",
+    "da"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/intake-holoviz.ipynb
+++ b/examples/intake-holoviz.ipynb
@@ -1,0 +1,145 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Intake-STAC + Holoviz Visualizations\n",
+    "\n",
+    "Intake-STAC takes advantage of Intake's built-in graphical user-interface (GUI), which can browse catalogs and display pre-defined interactive plots of assets. This interface is built using the [Panel](https://panel.holoviz.org) library, which is part of the [Holoviz](https://holoviz.org) collection of libraries for browser-based visualizations in Python."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%matplotlib inline\n",
+    "import intake"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load results from previous satsearch (see examples/aws-earth-search.ipynb )\n",
+    "from satstac import ItemCollection\n",
+    "items = ItemCollection.open('my-s2-l2a-cogs.json')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Intake-STAC built-in GUI\n",
+    "\n",
+    "Currently you can choose a `thumbnail` plot for RGB thumbs. Or a `geotiff` plot for dynamically-updating full resultion single band images (Warning, currently initializing plot can be slow for large geotiffs, likely can improve this in the future!)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "catalog = intake.open_stac_item_collection(items)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NOTE: import statement required for dynamic=True\n",
+    "import hvplot.xarray\n",
+    "intake.gui.add(catalog)\n",
+    "intake.gui"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Here's how you would load plots outside of the GUI\n",
+    "item = catalog['S2A_36MYB_20200814_0_L2A']\n",
+    "thumb = item['thumbnail']\n",
+    "da = thumb.to_dask()\n",
+    "da.hvplot.rgb(x='x', y='y', bands='channel',\n",
+    "              title=item.name,\n",
+    "              data_aspect=1, flip_yaxis=True, xaxis=False, yaxis=None)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Interactive plot with hvplot and datashader (dynamically-updated resolution)\n",
+    "da = item['B06'].to_dask()\n",
+    "da.sel(band=1).hvplot.image(x='x', y='y',\n",
+    "                title=f\"{item.name} - {item['B06'].description}\",\n",
+    "                rasterize=True, dynamic=True,\n",
+    "                frame_width=500, data_aspect=1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## ipywidgets\n",
+    "\n",
+    "[ipywidgets](https://ipywidgets.readthedocs.io/en/stable/) provide another convenient approach to custom visualizations. The function below allows us to browse through all the image thumbnails for a group of images."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from ipywidgets import interact\n",
+    "from IPython.display import display, Image\n",
+    "\n",
+    "def browse_images(items):\n",
+    "    n = len(items)\n",
+    "\n",
+    "    def view_image(i=0):\n",
+    "        item = items[i]\n",
+    "        print(f\"id={item.id}\\tdate={item.datetime}\\tcloud%={item['eo:cloud_cover']}\")\n",
+    "        display(Image(item.asset('thumbnail')['href']))\n",
+    "    \n",
+    "    interact(view_image, i=(0,n-1))\n",
+    "\n",
+    "browse_images(items)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/landsat8-l1.ipynb
+++ b/examples/landsat8-l1.ipynb
@@ -27,9 +27,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# for developement\n",
-    "%load_ext autoreload\n",
-    "%autoreload 2"
+    "# for development\n",
+    "#%load_ext autoreload\n",
+    "#%autoreload 2"
    ]
   },
   {
@@ -69,10 +69,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# list shows us the subcatalog, which we can load:\n",
     "# Drill down into subcatalogs\n",
-    "\n",
-    "# need to change this to work with multiple subcatalogs (currently only gets first)\n",
     "subcat = cat['stac-catalog-eo']\n",
     "list(subcat)"
    ]
@@ -83,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Drill down into subcatalogs\n",
+    "# Drill further down into subcatalogs\n",
     "subcat1 = subcat['landsat-8-l1']\n",
     "list(subcat1)"
    ]

--- a/examples/my-s2-l2a-cogs.json
+++ b/examples/my-s2-l2a-cogs.json
@@ -1,0 +1,3540 @@
+{
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2A_36MYB_20200814_0_L2A",
+      "bbox": [
+        34.79870551983084,
+        -3.7056906919566326,
+        35.755863403460744,
+        -2.7110273448887328
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [34.80044299251402, -3.7056906919566326],
+            [34.79870551983084, -2.712838434794184],
+            [35.755863403460744, -2.7110273448887328],
+            [35.58561393371855, -3.4903485137854644],
+            [35.53750206413227, -3.703878577458925],
+            [34.80044299251402, -3.7056906919566326]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-08-14T08:11:00Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "view:off_nadir": 0,
+        "proj:epsg": 32736,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2A_MSIL2A_20200814T074621_N0214_R135_T36MYB_20200814T103139",
+        "sentinel:data_coverage": 85.74,
+        "eo:cloud_cover": 47.78,
+        "sentinel:valid_cloud_cover": true,
+        "created": "2020-08-17T19:57:08.648Z",
+        "updated": "2020-08-17T19:57:08.648Z",
+        "sentinel:utm_zone": 36
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/8/14/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/8/14/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/8/14/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2A_36MYB_20200814_0_L2A"
+        },
+        {
+          "rel": "derived_from",
+          "href": "s3://cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/36/M/YB/2020/8/S2A_36MYB_20200814_0_L2A/S2A_36MYB_20200814_0_L2A.json",
+          "title": "Source STAC Item",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2B_36MYB_20200809_0_L2A",
+      "bbox": [
+        34.79870551983084,
+        -3.7056906919566326,
+        35.76700629249285,
+        -2.7110017811328926
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [34.80044299251402, -3.7056906919566326],
+            [34.79870551983084, -2.712838434794184],
+            [35.76700629249285, -2.7110017811328926],
+            [35.59534033727834, -3.4950217349500936],
+            [35.54865807009975, -3.7038464213259266],
+            [34.80044299251402, -3.7056906919566326]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-08-09T08:10:57Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "view:off_nadir": 0,
+        "proj:epsg": 32736,
+        "sentinel:utm_zone": 36,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2B_MSIL2A_20200809T074619_N0214_R135_T36MYB_20200809T103816",
+        "sentinel:data_coverage": 86.85,
+        "eo:cloud_cover": 77.28,
+        "sentinel:valid_cloud_cover": true,
+        "created": "2020-08-18T10:57:54.124Z",
+        "updated": "2020-08-18T10:57:54.124Z"
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/8/9/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/8/9/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/8/9/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2B_36MYB_20200809_0_L2A"
+        },
+        {
+          "title": "Source STAC Item",
+          "rel": "derived_from",
+          "href": "s3://cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/36/M/YB/2020/8/S2B_36MYB_20200809_0_L2A/S2B_36MYB_20200809_0_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2B_36MYB_20200806_0_L2A",
+      "bbox": [
+        35.361851558698646,
+        -3.704366288842677,
+        35.78841174435426,
+        -2.7109586089556537
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [35.361851558698646, -3.704366288842677],
+            [35.40381967148886, -3.5125664894255837],
+            [35.582659278647895, -2.7114114515918657],
+            [35.785723330760796, -2.7109586089556537],
+            [35.78841174435426, -3.7031212858685087],
+            [35.361851558698646, -3.704366288842677]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-08-06T08:01:02Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "view:off_nadir": 0,
+        "proj:epsg": 32736,
+        "sentinel:utm_zone": 36,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2B_MSIL2A_20200806T073619_N0214_R092_T36MYB_20200806T113023",
+        "sentinel:data_coverage": 31.77,
+        "eo:cloud_cover": 0,
+        "sentinel:valid_cloud_cover": true,
+        "created": "2020-08-17T20:39:17.063Z",
+        "updated": "2020-08-17T20:39:17.063Z"
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/8/6/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/8/6/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/8/6/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2B_36MYB_20200806_0_L2A"
+        },
+        {
+          "title": "Source STAC Item",
+          "rel": "derived_from",
+          "href": "s3://cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/36/M/YB/2020/8/S2B_36MYB_20200806_0_L2A/S2B_36MYB_20200806_0_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2A_36MYB_20200804_0_L2A",
+      "bbox": [
+        34.79870551983084,
+        -3.7056906919566326,
+        35.757300644517535,
+        -2.7110240533940337
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [34.80044299251402, -3.7056906919566326],
+            [34.79870551983084, -2.712838434794184],
+            [35.757300644517535, -2.7110240533940337],
+            [35.593185658988496, -3.4635764446186035],
+            [35.539121505336155, -3.7038739183195086],
+            [34.80044299251402, -3.7056906919566326]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-08-04T08:11:00Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "view:off_nadir": 0,
+        "proj:epsg": 32736,
+        "sentinel:utm_zone": 36,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2A_MSIL2A_20200804T074621_N0214_R135_T36MYB_20200804T104333",
+        "sentinel:data_coverage": 85.89,
+        "eo:cloud_cover": 75.37,
+        "sentinel:valid_cloud_cover": true,
+        "created": "2020-08-17T21:33:14.530Z",
+        "updated": "2020-08-17T21:33:14.530Z"
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/8/4/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/8/4/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/8/4/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2A_36MYB_20200804_0_L2A"
+        },
+        {
+          "title": "Source STAC Item",
+          "rel": "derived_from",
+          "href": "s3://cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/36/M/YB/2020/8/S2A_36MYB_20200804_0_L2A/S2A_36MYB_20200804_0_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2A_36MYB_20200801_0_L2A",
+      "bbox": [
+        35.354473584331565,
+        -3.704386009664254,
+        35.78841174435426,
+        -2.7109586089556537
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [35.354473584331565, -3.704386009664254],
+            [35.3944358874427, -3.5225127312927675],
+            [35.53486937287048, -2.8896897890758986],
+            [35.574751456777825, -2.7114283938558765],
+            [35.785723330760796, -2.7109586089556537],
+            [35.78841174435426, -3.7031212858685087],
+            [35.354473584331565, -3.704386009664254]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-08-01T08:01:05Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "view:off_nadir": 0,
+        "proj:epsg": 32736,
+        "sentinel:utm_zone": 36,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2A_MSIL2A_20200801T073621_N0214_R092_T36MYB_20200801T102406",
+        "sentinel:data_coverage": 32.57,
+        "eo:cloud_cover": 62.8,
+        "sentinel:valid_cloud_cover": true,
+        "created": "2020-08-18T10:54:09.447Z",
+        "updated": "2020-08-18T10:54:09.447Z"
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/8/1/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/8/1/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/8/1/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2A_36MYB_20200801_0_L2A"
+        },
+        {
+          "title": "Source STAC Item",
+          "rel": "derived_from",
+          "href": "s3://cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/36/M/YB/2020/8/S2A_36MYB_20200801_0_L2A/S2A_36MYB_20200801_0_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2B_36MYB_20200730_0_L2A",
+      "bbox": [
+        34.79870551983084,
+        -3.7056906919566326,
+        35.7687137359457,
+        -2.7109978548485385
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [34.80044299251402, -3.7056906919566326],
+            [34.79870551983084, -2.712838434794184],
+            [35.7687137359457, -2.7109978548485385],
+            [35.602303822311306, -3.471108470253178],
+            [35.5503674728783, -3.703841481678485],
+            [34.80044299251402, -3.7056906919566326]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-07-30T08:10:57Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "view:off_nadir": 0,
+        "proj:epsg": 32736,
+        "sentinel:utm_zone": 36,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2B_MSIL2A_20200730T074619_N0214_R135_T36MYB_20200730T111202",
+        "sentinel:data_coverage": 87.03,
+        "eo:cloud_cover": 5.89,
+        "sentinel:valid_cloud_cover": true,
+        "created": "2020-08-18T09:45:24.058Z",
+        "updated": "2020-08-18T09:45:24.058Z"
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/7/30/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/30/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/30/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2B_36MYB_20200730_0_L2A"
+        },
+        {
+          "title": "Source STAC Item",
+          "rel": "derived_from",
+          "href": "s3://cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/36/M/YB/2020/7/S2B_36MYB_20200730_0_L2A/S2B_36MYB_20200730_0_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2B_36MYB_20200727_0_L2A",
+      "bbox": [
+        35.364731107030785,
+        -3.704358575275874,
+        35.78841174435426,
+        -2.7109586089556537
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [35.364731107030785, -3.704358575275874],
+            [35.40440599150377, -3.5241264913281642],
+            [35.58517559334435, -2.711406049575985],
+            [35.785723330760796, -2.7109586089556537],
+            [35.78841174435426, -3.7031212858685087],
+            [35.364731107030785, -3.704358575275874]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-07-27T08:01:01Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "view:off_nadir": 0,
+        "proj:epsg": 32736,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2B_MSIL2A_20200727T073619_N0214_R092_T36MYB_20200727T122549",
+        "sentinel:data_coverage": 31.47,
+        "eo:cloud_cover": 49.45,
+        "sentinel:valid_cloud_cover": true,
+        "created": "2020-07-27T23:47:07.484Z",
+        "updated": "2020-07-27T23:47:07.484Z"
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/7/27/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/27/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/27/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200727_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2B_36MYB_20200727_0_L2A"
+        },
+        {
+          "title": "Source STAC Item",
+          "rel": "derived_from",
+          "href": "/tmp/tmplhh8ay08/s3:/cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/2020/S2B_36MYB_20200727_0_L2A/S2B_36MYB_20200727_0_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2A_36MYB_20200725_0_L2A",
+      "bbox": [
+        34.79870551983084,
+        -3.7056906919566326,
+        35.759906699226775,
+        -2.7110180807693265
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [34.80044299251402, -3.7056906919566326],
+            [34.79870551983084, -2.712838434794184],
+            [35.759906699226775, -2.7110180807693265],
+            [35.58973859625803, -3.4867218329449443],
+            [35.54119098027402, -3.703867960107399],
+            [34.80044299251402, -3.7056906919566326]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-07-25T08:10:59Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "view:off_nadir": 0,
+        "proj:epsg": 32736,
+        "sentinel:utm_zone": 36,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2A_MSIL2A_20200725T074621_N0214_R135_T36MYB_20200725T111115",
+        "sentinel:data_coverage": 86.12,
+        "eo:cloud_cover": 1.01,
+        "sentinel:valid_cloud_cover": true,
+        "created": "2020-08-18T10:54:56.621Z",
+        "updated": "2020-08-18T10:54:56.621Z"
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/7/25/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/25/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/25/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2A_36MYB_20200725_0_L2A"
+        },
+        {
+          "title": "Source STAC Item",
+          "rel": "derived_from",
+          "href": "s3://cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/36/M/YB/2020/7/S2A_36MYB_20200725_0_L2A/S2A_36MYB_20200725_0_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.1",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2A_36MYB_20200722_0_L2A",
+      "bbox": [
+        35.356453603399366,
+        -3.704380723262607,
+        35.78841174435426,
+        -2.7109586089556537
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [35.356453603399366, -3.704380723262607],
+            [35.39652214425136, -3.52401250696652],
+            [35.57744628705123, -2.7114226260972907],
+            [35.785723330760796, -2.7109586089556537],
+            [35.78841174435426, -3.7031212858685087],
+            [35.356453603399366, -3.704380723262607]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-07-22T08:01:04Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "data_coverage": 32.26,
+        "view:off_nadir": 0,
+        "eo:cloud_cover": 69.73,
+        "proj:epsg": 32736,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2A_MSIL2A_20200722T073621_N0214_R092_T36MYB_20200722T105841",
+        "created": "2020-07-22T18:27:24.104Z",
+        "updated": "2020-07-22T18:27:24.104Z"
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/7/22/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/22/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/22/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200722_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2A_36MYB_20200722_0_L2A"
+        },
+        {
+          "title": "Source STAC Item",
+          "rel": "derived_from",
+          "href": "/tmp/tmpcaywp_rx/s3:/cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/2020/S2A_36MYB_20200722_0_L2A/S2A_36MYB_20200722_0_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.1",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2B_36MYB_20200720_0_L2A",
+      "bbox": [
+        34.79870551983084,
+        -3.7056906919566326,
+        35.77185877492271,
+        -2.710990616463335
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [34.80044299251402, -3.7056906919566326],
+            [34.79870551983084, -2.712838434794184],
+            [35.77185877492271, -2.710990616463335],
+            [35.610236308119404, -3.449883225671188],
+            [35.5534261567553, -3.7038326347645305],
+            [34.80044299251402, -3.7056906919566326]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-07-20T08:10:56Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "data_coverage": 87.34,
+        "view:off_nadir": 0,
+        "eo:cloud_cover": 14.84,
+        "proj:epsg": 32736,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2B_MSIL2A_20200720T074619_N0214_R135_T36MYB_20200720T112901",
+        "created": "2020-07-21T07:13:58.404Z",
+        "updated": "2020-07-21T07:13:58.404Z"
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/7/20/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/20/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/20/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200720_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2B_36MYB_20200720_0_L2A"
+        },
+        {
+          "title": "Source STAC Item",
+          "rel": "derived_from",
+          "href": "/tmp/tmpmg_02hsf/s3:/cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/2020/S2B_36MYB_20200720_0_L2A/S2B_36MYB_20200720_0_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.1",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2B_36MYB_20200717_0_L2A",
+      "bbox": [
+        35.36833009312432,
+        -3.704348921313967,
+        35.78841174435426,
+        -2.7109586089556537
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [35.36833009312432, -3.704348921313967],
+            [35.407819165099255, -3.5245820359904383],
+            [35.588411026975066, -2.7113990960324563],
+            [35.785723330760796, -2.7109586089556537],
+            [35.78841174435426, -3.7031212858685087],
+            [35.36833009312432, -3.704348921313967]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-07-17T08:01:00Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "data_coverage": 31.12,
+        "view:off_nadir": 0,
+        "eo:cloud_cover": 99.94,
+        "proj:epsg": 32736,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2B_MSIL2A_20200717T073619_N0214_R092_T36MYB_20200718T133139",
+        "created": "2020-07-19T06:34:06.931Z",
+        "updated": "2020-07-19T06:34:06.931Z"
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/7/17/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/17/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/17/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200717_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2B_36MYB_20200717_0_L2A"
+        },
+        {
+          "title": "Source STAC Item",
+          "rel": "derived_from",
+          "href": "/tmp/tmpt7qy_3d4/s3:/cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/2020/S2B_36MYB_20200717_0_L2A/S2B_36MYB_20200717_0_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.1",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2A_36MYB_20200715_0_L2A",
+      "bbox": [
+        34.79870551983084,
+        -3.7056906919566326,
+        35.762423439929975,
+        -2.7110123074852157
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [34.80044299251402, -3.7056906919566326],
+            [34.79870551983084, -2.712838434794184],
+            [35.762423439929975, -2.7110123074852157],
+            [35.58950948158126, -3.500550130276924],
+            [35.54379972231785, -3.7038604423827857],
+            [34.80044299251402, -3.7056906919566326]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-07-15T08:10:59Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "data_coverage": 86.39,
+        "view:off_nadir": 0,
+        "eo:cloud_cover": 98.19,
+        "proj:epsg": 32736,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2A_MSIL2A_20200715T074621_N0214_R135_T36MYB_20200715T120435",
+        "created": "2020-07-15T19:45:19.488Z",
+        "updated": "2020-07-15T19:45:19.488Z"
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/7/15/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/15/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/15/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200715_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2A_36MYB_20200715_0_L2A"
+        },
+        {
+          "title": "Source STAC Item",
+          "rel": "derived_from",
+          "href": "/tmp/tmpbsmlmfb3/s3:/cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/2020/S2A_36MYB_20200715_0_L2A/S2A_36MYB_20200715_0_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2A_36MYB_20200712_0_L2A",
+      "bbox": [
+        35.36185349129008,
+        -3.7043662836689135,
+        35.78841174435426,
+        -2.7109586089556537
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [35.36185349129008, -3.7043662836689135],
+            [35.527401739826665, -2.9456144416642576],
+            [35.579424700604456, -2.711418387850691],
+            [35.785723330760796, -2.7109586089556537],
+            [35.78841174435426, -3.7031212858685087],
+            [35.36185349129008, -3.7043662836689135]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-07-12T08:01:03Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "data_coverage": 31.92,
+        "view:off_nadir": 0,
+        "eo:cloud_cover": 12.02,
+        "proj:epsg": 32736,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2A_MSIL2A_20200712T073621_N0214_R092_T36MYB_20200712T110016",
+        "created": "2020-08-18T09:03:03.858Z",
+        "updated": "2020-08-18T09:03:03.858Z",
+        "sentinel:valid_cloud_cover": true,
+        "sentinel:utm_zone": 36,
+        "sentinel:data_coverage": 31.92
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/7/12/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/12/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/12/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2A_36MYB_20200712_0_L2A"
+        },
+        {
+          "rel": "derived_from",
+          "href": "s3://cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/36/M/YB/2020/7/S2A_36MYB_20200712_0_L2A/S2A_36MYB_20200712_0_L2A.json",
+          "title": "Source STAC Item",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.2",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2B_36MYB_20200710_0_L2A",
+      "bbox": [
+        34.79870551983084,
+        -3.7056906919566326,
+        35.77024131589214,
+        -2.7109943401109917
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [34.80044299251402, -3.7056906919566326],
+            [34.79870551983084, -2.712838434794184],
+            [35.77024131589214, -2.7109943401109917],
+            [35.60554409132611, -3.4622467746776224],
+            [35.55171700875178, -3.7038375795975336],
+            [34.80044299251402, -3.7056906919566326]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-07-10T08:10:56Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "data_coverage": 87.17,
+        "view:off_nadir": 0,
+        "eo:cloud_cover": 10.17,
+        "proj:epsg": 32736,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2B_MSIL2A_20200710T074619_N0214_R135_T36MYB_20200710T115611",
+        "created": "2020-08-18T12:01:03.380Z",
+        "updated": "2020-08-18T12:01:03.380Z",
+        "sentinel:valid_cloud_cover": true,
+        "sentinel:utm_zone": 36,
+        "sentinel:data_coverage": 87.17
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/7/10/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/10/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/10/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2B_36MYB_20200710_0_L2A"
+        },
+        {
+          "rel": "derived_from",
+          "href": "s3://cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/36/M/YB/2020/7/S2B_36MYB_20200710_0_L2A/S2B_36MYB_20200710_0_L2A.json",
+          "title": "Source STAC Item",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.1",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2B_36MYB_20200707_0_L2A",
+      "bbox": [
+        35.363651831328085,
+        -3.704361467477506,
+        35.78841174435426,
+        -2.7109586089556537
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [35.363651831328085, -3.704361467477506],
+            [35.58391733787192, -2.7114087514517324],
+            [35.785723330760796, -2.7109586089556537],
+            [35.78841174435426, -3.7031212858685087],
+            [35.363651831328085, -3.704361467477506]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-07-07T08:01:01Z",
+        "platform": "sentinel-2b",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "data_coverage": 31.59,
+        "view:off_nadir": 0,
+        "eo:cloud_cover": 19.61,
+        "proj:epsg": 32736,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2B_MSIL2A_20200707T073619_N0214_R092_T36MYB_20200707T113322",
+        "created": "2020-07-07T18:01:16.401Z",
+        "updated": "2020-07-07T18:01:16.401Z"
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/7/7/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/7/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/7/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2B_36MYB_20200707_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2B_36MYB_20200707_0_L2A"
+        },
+        {
+          "title": "Source STAC Item",
+          "rel": "derived_from",
+          "href": "/tmp/tmpcr9q6lgo/s3:/cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/2020/S2B_36MYB_20200707_0_L2A/S2B_36MYB_20200707_0_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    },
+    {
+      "type": "Feature",
+      "stac_version": "1.0.0-beta.1",
+      "stac_extensions": ["eo", "view", "proj"],
+      "id": "S2A_36MYB_20200702_0_L2A",
+      "bbox": [
+        35.356093300381986,
+        -3.704381685556869,
+        35.78841174435426,
+        -2.7109586089556537
+      ],
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [35.356093300381986, -3.704381685556869],
+            [35.39966829397743, -3.506566766775803],
+            [35.57726786230264, -2.7114230081670594],
+            [35.785723330760796, -2.7109586089556537],
+            [35.78841174435426, -3.7031212858685087],
+            [35.356093300381986, -3.704381685556869]
+          ]
+        ]
+      },
+      "properties": {
+        "datetime": "2020-07-02T08:01:04Z",
+        "platform": "sentinel-2a",
+        "constellation": "sentinel-2",
+        "instruments": ["msi"],
+        "gsd": 10,
+        "data_coverage": 32.37,
+        "view:off_nadir": 0,
+        "eo:cloud_cover": 55.53,
+        "proj:epsg": 32736,
+        "sentinel:latitude_band": "M",
+        "sentinel:grid_square": "YB",
+        "sentinel:sequence": "0",
+        "sentinel:product_id": "S2A_MSIL2A_20200702T073621_N0214_R092_T36MYB_20200702T105954",
+        "created": "2020-07-02T19:20:53.603Z",
+        "updated": "2020-07-02T19:20:53.603Z"
+      },
+      "collection": "sentinel-s2-l2a-cogs",
+      "assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l1c/tiles/36/M/YB/2020/7/2/0/preview.jpg"
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/L2A_PVI.tif",
+          "proj:shape": [343, 343],
+          "proj:transform": [320, 0, 699960, 0, -320, 9700000, 0, 0, 1]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/2/0/tileInfo.json"
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "href": "https://roda.sentinel-hub.com/sentinel-s2-l2a/tiles/36/M/YB/2020/7/2/0/metadata.xml"
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/TCI.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/B01.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/B02.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/B03.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/B04.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/B05.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/B06.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/B07.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/B08.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/B8A.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/B09.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/B11.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/B12.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/AOT.tif",
+          "proj:shape": [1830, 1830],
+          "proj:transform": [60, 0, 699960, 0, -60, 9700000, 0, 0, 1]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/WVP.tif",
+          "proj:shape": [10980, 10980],
+          "proj:transform": [10, 0, 699960, 0, -10, 9700000, 0, 0, 1]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "href": "https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/2020/S2A_36MYB_20200702_0_L2A/SCL.tif",
+          "proj:shape": [5490, 5490],
+          "proj:transform": [20, 0, 699960, 0, -20, 9700000, 0, 0, 1]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items/S2A_36MYB_20200702_0_L2A"
+        },
+        {
+          "title": "Source STAC Item",
+          "rel": "derived_from",
+          "href": "/tmp/tmpnnkrg0ll/s3:/cirrus-v0-data-1qm7gekzjucbq/sentinel-s2-l2a/2020/S2A_36MYB_20200702_0_L2A/S2A_36MYB_20200702_0_L2A.json",
+          "type": "application/json"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "collection",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" }
+      ]
+    }
+  ],
+  "collections": [
+    {
+      "stac_version": "1.0.0-beta.1",
+      "stac_extensions": ["item-assets"],
+      "id": "sentinel-s2-l2a-cogs",
+      "title": "Sentinel 2 L2A COGs",
+      "description": "Sentinel-2a and Sentinel-2b imagery, processed to Level 2A (Surface Reflectance) and converted to Cloud-Optimized GeoTIFFs",
+      "keywords": ["sentinel", "earth observation", "esa"],
+      "extent": {
+        "spatial": [-180, -90, 180, 90],
+        "temporal": ["2015-06-27T10:25:31.456Z", null]
+      },
+      "providers": [
+        {
+          "name": "ESA",
+          "roles": ["producer"],
+          "url": "https://earth.esa.int/web/guest/home"
+        },
+        {
+          "name": "Sinergise",
+          "roles": ["processor"],
+          "url": "https://registry.opendata.aws/sentinel-2/"
+        },
+        {
+          "name": "AWS",
+          "roles": ["host"],
+          "url": "http://sentinel-pds.s3-website.eu-central-1.amazonaws.com/"
+        },
+        {
+          "name": "Element 84",
+          "roles": ["processor"],
+          "url": "https://element84.com"
+        }
+      ],
+      "license": "proprietary",
+      "summaries": {
+        "platform": ["sentinel-2a", "sentinel-2b"],
+        "constellation": ["sentinel-2"],
+        "instruments": ["msi"],
+        "gsd": [10],
+        "view:off_nadir": [0]
+      },
+      "item_assets": {
+        "thumbnail": {
+          "title": "Thumbnail",
+          "type": "image/png",
+          "roles": ["thumbnail"]
+        },
+        "overview": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["overview"],
+          "gsd": 10,
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.6645,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.4966,
+              "full_width_half_max": 0.098
+            }
+          ]
+        },
+        "info": {
+          "title": "Original JSON metadata",
+          "type": "application/json",
+          "roles": ["metadata"]
+        },
+        "metadata": {
+          "title": "Original XML metadata",
+          "type": "application/xml",
+          "roles": ["metadata"]
+        },
+        "visual": {
+          "title": "True color image",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["overview"],
+          "gsd": 10,
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.6645,
+              "full_width_half_max": 0.038
+            },
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            },
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.4966,
+              "full_width_half_max": 0.098
+            }
+          ]
+        },
+        "B01": {
+          "title": "Band 1 (coastal)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["data"],
+          "gsd": 60,
+          "eo:bands": [
+            {
+              "name": "B01",
+              "common_name": "coastal",
+              "center_wavelength": 0.4439,
+              "full_width_half_max": 0.027
+            }
+          ]
+        },
+        "B02": {
+          "title": "Band 2 (blue)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["data"],
+          "gsd": 10,
+          "eo:bands": [
+            {
+              "name": "B02",
+              "common_name": "blue",
+              "center_wavelength": 0.4966,
+              "full_width_half_max": 0.098
+            }
+          ]
+        },
+        "B03": {
+          "title": "Band 3 (green)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["data"],
+          "gsd": 10,
+          "eo:bands": [
+            {
+              "name": "B03",
+              "common_name": "green",
+              "center_wavelength": 0.56,
+              "full_width_half_max": 0.045
+            }
+          ]
+        },
+        "B04": {
+          "title": "Band 4 (red)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["data"],
+          "gsd": 10,
+          "eo:bands": [
+            {
+              "name": "B04",
+              "common_name": "red",
+              "center_wavelength": 0.6645,
+              "full_width_half_max": 0.038
+            }
+          ]
+        },
+        "B05": {
+          "title": "Band 5",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["data"],
+          "gsd": 20,
+          "eo:bands": [
+            {
+              "name": "B05",
+              "center_wavelength": 0.7039,
+              "full_width_half_max": 0.019
+            }
+          ]
+        },
+        "B06": {
+          "title": "Band 6",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["data"],
+          "gsd": 20,
+          "eo:bands": [
+            {
+              "name": "B06",
+              "center_wavelength": 0.7402,
+              "full_width_half_max": 0.018
+            }
+          ]
+        },
+        "B07": {
+          "title": "Band 7",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["data"],
+          "gsd": 20,
+          "eo:bands": [
+            {
+              "name": "B07",
+              "center_wavelength": 0.7825,
+              "full_width_half_max": 0.028
+            }
+          ]
+        },
+        "B08": {
+          "title": "Band 8 (nir)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["data"],
+          "gsd": 10,
+          "eo:bands": [
+            {
+              "name": "B08",
+              "common_name": "nir",
+              "center_wavelength": 0.8351,
+              "full_width_half_max": 0.145
+            }
+          ]
+        },
+        "B8A": {
+          "title": "Band 8A",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["data"],
+          "gsd": 20,
+          "eo:bands": [
+            {
+              "name": "B8A",
+              "center_wavelength": 0.8648,
+              "full_width_half_max": 0.033
+            }
+          ]
+        },
+        "B09": {
+          "title": "Band 9",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["data"],
+          "gsd": 60,
+          "eo:bands": [
+            {
+              "name": "B09",
+              "center_wavelength": 0.945,
+              "full_width_half_max": 0.026
+            }
+          ]
+        },
+        "B11": {
+          "title": "Band 11 (swir16)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["data"],
+          "gsd": 20,
+          "eo:bands": [
+            {
+              "name": "B11",
+              "common_name": "swir16",
+              "center_wavelength": 1.6137,
+              "full_width_half_max": 0.143
+            }
+          ]
+        },
+        "B12": {
+          "title": "Band 12 (swir22)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["data"],
+          "gsd": 20,
+          "eo:bands": [
+            {
+              "name": "B12",
+              "common_name": "swir22",
+              "center_wavelength": 2.22024,
+              "full_width_half_max": 0.242
+            }
+          ]
+        },
+        "AOT": {
+          "title": "Aerosol Optical Thickness (AOT)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["data"]
+        },
+        "WVP": {
+          "title": "Water Vapour (WVP)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["data"]
+        },
+        "SCL": {
+          "title": "Scene Classification Map (SCL)",
+          "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+          "roles": ["data"]
+        }
+      },
+      "links": [
+        {
+          "rel": "self",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs"
+        },
+        {
+          "rel": "license",
+          "href": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"
+        },
+        {
+          "rel": "about",
+          "href": "https://github.com/stac-utils/stac-sentinel"
+        },
+        {
+          "rel": "parent",
+          "href": "https://earth-search.aws.element84.com/v0/"
+        },
+        { "rel": "root", "href": "https://earth-search.aws.element84.com/v0/" },
+        {
+          "rel": "items",
+          "href": "https://earth-search.aws.element84.com/v0/collections/sentinel-s2-l2a-cogs/items"
+        }
+      ]
+    }
+  ]
+}

--- a/examples/planet-disaster-data.ipynb
+++ b/examples/planet-disaster-data.ipynb
@@ -63,16 +63,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "intake.gui.add(cat)\n",
-    "intake.gui"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# STAC files are in JSON format, which is accessible as Python dictionaries:\n",
     "cat.metadata"
    ]

--- a/examples/planet-disaster-data.ipynb
+++ b/examples/planet-disaster-data.ipynb
@@ -63,6 +63,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "intake.gui.add(cat)\n",
+    "intake.gui"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# STAC files are in JSON format, which is accessible as Python dictionaries:\n",
     "cat.metadata"
    ]

--- a/intake_stac/catalog.py
+++ b/intake_stac/catalog.py
@@ -1,13 +1,11 @@
 import os.path
+import warnings
 
 import satstac
 import yaml
 from intake.catalog import Catalog
 from intake.catalog.local import LocalCatalogEntry
 from pkg_resources import get_distribution
-
-# import warnings
-
 
 __version__ = get_distribution('intake_stac').version
 
@@ -452,10 +450,10 @@ class StacEntry(LocalCatalogEntry):
             suffix = os.path.splitext(entry['href'])[-1]
             if suffix in ['.nc', '.h5', '.hdf']:
                 entry_type = 'application/netcdf'
-            # produces excess output for large catalogs
-            #    warnings.warn(
-            #        f'TODO: handle case with entry without type field. This entry was: {entry}'
-            #    )
+            else:
+                warnings.warn(
+                    f'TODO: handle case with entry without type field. This entry was: {entry}'
+                )
 
         return drivers.get(entry_type, entry_type)
 


### PR DESCRIPTION
Fixes #34 

Wrapped up the STAC-sprint by tackling one more issue. Now the Intake GUI works for a few mimetypes (thumbnail images and tiffs! Added an example notebook illustrating the functionality and updated binder configuration, would be cool to add a short animated GIF to the docs or even the readme!

https://mybinder.org/v2/gh/scottyhq/intake-stac/gui?urlpath=lab