### PR TITLE
add nightly test, stop testing against python 3.6

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -1,26 +1,12 @@
-name: CI
+# Run a nightly test against unpinned conda environment
+name: Cron
 
 on:
-  push:
-    branches: "*"
-  pull_request:
-    branches: master
+  schedule:
+    - cron: "0 0 * * *"
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-      - uses: pre-commit/action@v2.0.0
-
   test:
-    name: ${{ matrix.CONDA_ENV }}-test
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        CONDA_ENV: [3.7, 3.8, 3.9, upstream]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -31,7 +17,7 @@ jobs:
           auto-update-conda: true
           auto-activate-base: false
           activate-environment: intake-stac
-          environment-file: ci/environment-${{ matrix.CONDA_ENV }}.yml
+          environment-file: ci/environment-unpinned.yml
 
       - name: Development Install Intake-STAC
         shell: bash -l {0}

--- a/ci/environment-unpinned.yml
+++ b/ci/environment-unpinned.yml
@@ -2,7 +2,7 @@ name: intake-stac
 channels:
   - conda-forge
 dependencies:
-  - python=3.6
+  - python
   - fsspec
   - geopandas
   - intake


### PR DESCRIPTION
currently this repo doesn't have a lot of PRs going in so CI tests aren't run frequently. I thought a nightly run of tests against an unpinned conda environment would be helpful. 

Also following xarray to just test against python>3.7 (https://github.com/pydata/xarray/issues/4688)