### PR TITLE
master --> main rename

### DIFF
--- a/.binder/environment.yml
+++ b/.binder/environment.yml
@@ -1,0 +1,44 @@
+# binder development environment
+name: intake-stac-dev
+channels:
+  - conda-forge
+dependencies:
+  - aiohttp
+  - bokeh=2.2
+  - coverage
+  - dask
+  - dask-labextension
+  - datashader
+  - distributed
+  - gcsfs
+  - geopandas
+  - geoviews
+  - h5netcdf
+  - hvplot
+  - intake
+  - intake-geopandas
+  - intake-parquet
+  - intake-xarray
+  - ipywidgets
+  - ipyleaflet
+  - jupyterlab>=3
+  - matplotlib-base
+  - netcdf4
+  - numpy
+  - panel
+  - pip
+  - pyproj
+  - python=3.8
+  - pyyaml
+  - pystac
+  - pytest
+  - rasterio
+  - rioxarray
+  - requests
+  - s3fs
+  - sat-search
+  - sat-stac
+  - scikit-image
+  - xarray
+  - pip:
+      - -e ../

--- a/.github/workflows/binderbadge.yaml
+++ b/.github/workflows/binderbadge.yaml
@@ -1,0 +1,26 @@
+# create a mybinder badge issue comment for testing PRs
+name: AddBinderBadge
+on:
+  pull_request:
+    types: [opened, reopened]
+jobs:
+  build-image-without-pushing:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR
+        uses: actions/checkout@v2
+
+      - name: Comment on PR with Binder link
+        uses: actions/github-script@v3
+        env:
+          BRANCH_NAME: ${{ github.event.pull_request.head.ref }}
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+            var BRANCH_NAME = process.env.BRANCH_NAME;
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/${context.repo.owner}/${context.repo.repo}/${BRANCH_NAME}) :point_left: Launch a binder notebook on this branch`
+            })

--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -30,9 +30,3 @@ jobs:
         shell: bash -l {0}
         run: |
           pytest --verbose --junitxml=test-reports/junit.xml --cov=intake_stac --cov-config ci/.coveragerc --cov-report term-missing
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          file: test-reports/junit.xml

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -4,7 +4,7 @@ on:
   push:
     branches: "*"
   pull_request:
-    branches: master
+    branches: main
 
 jobs:
   lint:

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Intake-STAC
 
 ![CI](https://github.com/pangeo-data/intake-stac/workflows/CI/badge.svg)
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pangeo-data/intake-stac/master?urlpath=lab/tree/examples)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pangeo-data/intake-stac/binder?urlpath=git-pull%3Frepo%3Dhttps%253A%252F%252Fgithub.com%252Fpangeo-data%252Fintake-stac%26urlpath%3Dlab%252Ftree%252Fintake-stac%252Fexamples%26branch%3Dmain)
 [![PyPI version](https://badge.fury.io/py/intake-stac.svg)](https://badge.fury.io/py/intake-stac)
 [![Documentation Status](https://readthedocs.org/projects/intake-stac/badge/?version=latest)](https://intake-stac.readthedocs.io/en/latest/?badge=latest)
-[![codecov](https://codecov.io/gh/pangeo-data/intake-stac/branch/master/graph/badge.svg)](https://codecov.io/gh/pangeo-data/intake-stac)
+[![codecov](https://codecov.io/gh/pangeo-data/intake-stac/branch/main/graph/badge.svg)](https://codecov.io/gh/pangeo-data/intake-stac)
 
 This is an [Intake](https://intake.readthedocs.io/en/latest) data source for [SpatioTemporal Asset Catalogs (STAC)](https://stacspec.org/). The STAC specification provides a common metadata specification, API, and catalog format to describe geospatial assets, so they can more easily indexed and discovered. A 'spatiotemporal asset' is any file that represents information about the earth captured in a certain space and time.
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -96,9 +96,9 @@ Preparing Pull Requests
     $ git clone git@github.com:YOUR_GITHUB_USERNAME/intake-stac.git
     $ cd intake-stac
 
-    # now, to fix a bug or add feature create your own branch off "master":
+    # now, to fix a bug or add feature create your own branch off "main":
 
-    $ git checkout -b your-bugfix-feature-branch-name master
+    $ git checkout -b your-bugfix-feature-branch-name main
 
 
 #. Install development version in a conda environment::
@@ -146,4 +146,4 @@ Preparing Pull Requests
     compare: your-branch-name
 
     base-fork: intake/intake-stac
-    base: master
+    base: main


### PR DESCRIPTION
- the binder environment in the main branch can now be used for development and testing PRs (installs branch in development mode w/ pip and adds binderbadge.yaml github action

- the binder link in the readme uses an environment definition in a separate branch that will install the latest released version of intake-stac and not rebuild when content changes (repo content pulled with nbgitpuller) 