### PR TITLE
update pystac dep to 1.0.0

### DIFF
--- a/ci/environment-3.7.yml
+++ b/ci/environment-3.7.yml
@@ -7,9 +7,7 @@ dependencies:
   - geopandas
   - intake
   - intake-xarray
+  - pystac
   - pytest-cov
   - rasterio
   - xarray
-  - pip
-  - pip:
-      - pystac>=1.0.0rc1

--- a/ci/environment-3.8.yml
+++ b/ci/environment-3.8.yml
@@ -7,8 +7,7 @@ dependencies:
   - geopandas
   - intake
   - intake-xarray
+  - pystac
   - pytest-cov
   - rasterio
   - xarray
-  - pip:
-      - pystac>=1.0.0rc1

--- a/ci/environment-3.9.yml
+++ b/ci/environment-3.9.yml
@@ -7,9 +7,7 @@ dependencies:
   - geopandas
   - intake
   - intake-xarray
+  - pystac
   - pytest-cov
   - rasterio
   - xarray
-  - pip
-  - pip:
-      - pystac>=1.0.0rc1

--- a/ci/environment-unpinned.yml
+++ b/ci/environment-unpinned.yml
@@ -7,9 +7,7 @@ dependencies:
   - geopandas
   - intake
   - intake-xarray
+  - pystac
   - pytest-cov
   - rasterio
   - xarray
-  - pip
-  - pip:
-      - pystac>=1.0.0rc1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fsspec>=0.8.4
 intake>=0.5.1
 intake-xarray>=0.4
-pystac>=1.0.0rc1
+pystac>=1.0.0


### PR DESCRIPTION
Minor changes to CI environments. Drops the release candidate and points to conda-forge.