### PR TITLE
feat: Add STAC item id to geopandas

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,12 +19,8 @@ repos:
     rev: 6.0.0
     hooks:
       - id: flake8
-  - repo: https://github.com/asottile/seed-isort-config
-    rev: v2.2.0
-    hooks:
-      - id: seed-isort-config
   - repo: https://github.com/PyCQA/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+- Add STAC item id to GeoDataFrame when calling `to_geopandas()` method (#158)
+
 ## [v0.4.0] - 2021-XX-XX
 
 - Switched from sat-stac to pystac dependency (#72)

--- a/ci/environment-docs.yml
+++ b/ci/environment-docs.yml
@@ -19,6 +19,7 @@ dependencies:
   - pystac-client
   - pytest-cov
   - rasterio
+  - rioxarray
   - scikit-image
   - sphinx
   - sphinx_rtd_theme

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -113,11 +113,11 @@ using `pystac-client`:
 .. ipython:: python
 
     import pystac_client
-    URL = "https://earth-search.aws.element84.com/v0"
+    URL = "https://earth-search.aws.element84.com/v1"
     catalog = pystac_client.Client.open(URL)
 
     results = catalog.search(
-        collections=["sentinel-s2-l2a-cogs"],
+        collections=["sentinel-2-l2a"],
         bbox = [35.48, -3.24, 35.58, -3.14],
         datetime="2020-07-01/2020-08-15")
 

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -121,7 +121,7 @@ using `pystac-client`:
         bbox = [35.48, -3.24, 35.58, -3.14],
         datetime="2020-07-01/2020-08-15")
 
-    items = results.get_all_items()
+    items = results.item_collection()
     print(len(items))
 
 In the code section above, `items` is a `pystac.ItemsCollection` object.

--- a/intake_stac/catalog.py
+++ b/intake_stac/catalog.py
@@ -276,10 +276,10 @@ class StacItemCollection(AbstractStacCatalog):
         gf = gpd.GeoDataFrame.from_features(self._stac_obj.to_dict(), crs=crs)
 
         # If no id in properties, use the STAC item id
-        if "id" not in gf.columns:
+        if 'id' not in gf.columns:
             items = self._stac_obj.items
             item_ids = [item.id for item in items]
-            gf["id"] = item_ids
+            gf['id'] = item_ids
 
         return gf
 

--- a/intake_stac/catalog.py
+++ b/intake_stac/catalog.py
@@ -274,6 +274,13 @@ class StacItemCollection(AbstractStacCatalog):
         if crs is None:
             crs = 'epsg:4326'
         gf = gpd.GeoDataFrame.from_features(self._stac_obj.to_dict(), crs=crs)
+
+        # If no id in properties, use the STAC item id
+        if "id" not in gf.columns:
+            items = self._stac_obj.items
+            item_ids = [item.id for item in items]
+            gf["id"] = item_ids
+
         return gf
 
 


### PR DESCRIPTION
When calling `to_geopandas()` the resulting GeoDataFrame has no `id` column indicating the STAC item id if it is not included in the STAC item properties. This small change checks if an `id` column is present in the GeoDataFrame, and if not, adds the STAC item ids.

Also fixes a CI build error caused by `seed-isort-config`, which is no longer maintained and is obsoleted by isort >= 5.0.0 ( https://github.com/asottile-archive/seed-isort-config/issues/72#issuecomment-665472797 ).

Also fixes a few sphinx build errors.